### PR TITLE
Change rr install

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,5 @@
+# Version 1.1
+
+* `rv` now opens a vanilla R in addition to `rn`.
+* `rr install` now will install a pacakge from either CRAN or GitHub, instead of loading the package.
+* Started versioning.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A plugin for R commands from your terminal.
 
 * `rr` - opens your R console.
 
-* `rn` - opens your R console without sourcing your `~/.Rprofile`.  (equivalent to `R --no-init-file`)
+* `rv` - opens your R console without sourcing your `~/.Rprofile`.  (equivalent to `R --vanilla`)
 
 * `rr document` - documents the R package that you are in.  `rr document <path/to/package>` documents that package (e.g., `rr document ~/dev/package`).
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ A plugin for R commands from your terminal.
 
 * `rr test` - runs the tests for the package you are in.  `rr test <path/to/package>` tests that package (e.g., `rr test ~/dev/package`).
 
-* `rr install` - installs a package.  `rr install <path/to/package>` installs that package (e.g., `rr install ~/dev/package`).
-
-* `rr install_github` - installs a package from github (e.g., `rr install peterhurford/batchman`).
+* `rr install` - installs a package.  `rr install <package name>` installs that package from CRAN.  `rr install <github_username>/<github_repo>` installs that package via `devtools::install_gihtub` (e.g., `rr install devtools`, `rr install peterhurford/batchman`).
 
 * `rr send <commit message>` - Like [send.zsh](https://github.com/robertzk/send.zsh), but hacked to include R.  If your repo is not a package, it will do `git add .`, `git commit -a -m <commit message>` and `git push origin <the branch you are on>`.  If you are in an R package directory, before doing that, it will document your code and run your tests.
 

--- a/rrzsh.plugin.zsh
+++ b/rrzsh.plugin.zsh
@@ -1,4 +1,4 @@
-alias 'rn'='R --no-init-file'
+alias 'rv'='R --vanilla'
 
 rr() {
   if [ $# -eq 0 ]; then; R

--- a/rrzsh.plugin.zsh
+++ b/rrzsh.plugin.zsh
@@ -1,4 +1,5 @@
 alias 'rv'='R --vanilla'
+alias 'rn'='R --vanilla'
 
 rr() {
   if [ $# -eq 0 ]; then; R
@@ -6,7 +7,6 @@ rr() {
   elif [ $1 = "test" ]; then rr_test $@
   elif [ $1 = "send" ]; then rr_send $@
   elif [ $1 = "install" ]; then rr_install $@
-  elif [ $1 = "install_github" ]; then rr_install_github $@
   else; Rscript -e $@
   fi
 }
@@ -27,15 +27,13 @@ rr_test() {
 
 rr_install() {
   shift
-  if [ $# -eq 0 ]; then; Rscript -e "library(methods); library(devtools); install()";
-  else; Rscript -e "library(methods); library(devtools); install($1);"
-  fi
-}
-
-rr_install_github() {
-  shift
-  if [ $# -eq 0 ]; then echo "You need to specify the repo.";
-  else; Rscript -e "library(methods); library(devtools); install_github('$1');"
+  if [ $# -eq 0 ]; then echo "You need to specify the package to install.";
+  elif grep -q "/" <<< "$1"; then
+    echo "Installing $1 from GitHub"
+    Rscript -e "library(methods); library(devtools); install_github('$1');"
+  else
+    echo "Installing $1 from CRAN..."
+    Rscript -e "library(methods); install.packages('$1');"
   fi
 }
 


### PR DESCRIPTION
rr install now won't `devtools::install` the package.  Instead it will either `install.packages` if the argument does not contain a slash, or `devtools::install_github` if the argument does contain a slash (e.g., user/repo).
